### PR TITLE
Add regex engine live demo with NFA/DFA visualization

### DIFF
--- a/src/app/projects/regex-engine/page.tsx
+++ b/src/app/projects/regex-engine/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useState } from 'react';
+import AutomatonGraph from '@/components/AutomatonGraph';
+import { buildNFAFromRegex, NFAToDFA, searchNFA, searchDFA, NFA, DFA } from '@/lib/regexEngine';
+import { nfaToGraph, dfaToGraph, Graph } from '@/lib/graphUtils';
+
+export default function RegexEngineDemo() {
+  const [pattern, setPattern] = useState('');
+  const [text, setText] = useState('');
+  const [nfa, setNfa] = useState<NFA | null>(null);
+  const [dfa, setDfa] = useState<DFA | null>(null);
+  const [graph, setGraph] = useState<Graph | null>(null);
+  const [matches, setMatches] = useState<Array<{start:number,end:number}>>([]);
+
+  const handleCreateNFA = () => {
+    try {
+      const nfa = buildNFAFromRegex(pattern);
+      setNfa(nfa);
+      setGraph(nfaToGraph(nfa));
+      setDfa(null);
+      setMatches([]);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleConvert = () => {
+    if (!nfa) return;
+    const dfa = NFAToDFA(nfa);
+    setDfa(dfa);
+    setGraph(dfaToGraph(dfa));
+    setMatches([]);
+  };
+
+  const handleUseNFA = () => {
+    if (!nfa) return;
+    const res = searchNFA(nfa, text);
+    setMatches(res);
+  };
+
+  const handleUseDFA = () => {
+    if (!dfa) return;
+    const res = searchDFA(dfa, text);
+    setMatches(res);
+  };
+
+  const highlighted = () => {
+    if (!matches.length) return text;
+    const parts = [] as any[];
+    let last = 0;
+    const sorted = [...matches].sort((a,b)=>a.start-b.start);
+    for (const m of sorted) {
+      if (m.start > last) parts.push(text.slice(last, m.start));
+      parts.push(<mark key={m.start+"-"+m.end} className="bg-yellow-300 text-black">{text.slice(m.start, m.end)}</mark>);
+      last = m.end;
+    }
+    parts.push(text.slice(last));
+    return parts;
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold">Regular Expression Engine Demo</h1>
+      <div className="flex flex-col gap-2 max-w-xl">
+        <input className="border p-2" placeholder="Regex" value={pattern} onChange={e=>setPattern(e.target.value)} />
+        <textarea className="border p-2" placeholder="Text" value={text} onChange={e=>setText(e.target.value)} />
+        <button className="bg-blue-500 text-white px-4 py-2" onClick={handleCreateNFA}>Create NFA</button>
+        {nfa && (
+          <div className="flex gap-2">
+            <button className="bg-green-500 text-white px-4 py-2" onClick={handleUseNFA}>Use NFA</button>
+            <button className="bg-purple-500 text-white px-4 py-2" onClick={handleConvert}>Convert NFA to DFA</button>
+          </div>
+        )}
+        {dfa && (
+          <button className="bg-green-700 text-white px-4 py-2" onClick={handleUseDFA}>Use DFA</button>
+        )}
+      </div>
+      {graph && <AutomatonGraph graph={graph} />}
+      <div className="p-2 border min-h-[2rem]">{highlighted()}</div>
+    </div>
+  );
+}

--- a/src/components/AutomatonGraph.tsx
+++ b/src/components/AutomatonGraph.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React from 'react';
+import ReactFlow, { Background, Controls, MiniMap } from '@reactflow/core';
+import type { Graph } from '@/lib/graphUtils';
+import '@reactflow/core/dist/style.css';
+
+interface Props {
+  graph: Graph;
+}
+
+export default function AutomatonGraph({ graph }: Props) {
+  return (
+    <div style={{ width: '100%', height: '400px' }}>
+      <ReactFlow nodes={graph.nodes} edges={graph.edges} fitView>
+        <Background />
+        <Controls />
+        <MiniMap />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/src/lib/graphUtils.ts
+++ b/src/lib/graphUtils.ts
@@ -1,0 +1,53 @@
+import { NFA, DFA } from './regexEngine';
+
+interface Node { id: string; position: {x:number;y:number}; data:{label:string}; style?: any; }
+interface Edge { id:string; source:string; target:string; label?:string; }
+
+export type Graph = { nodes: Node[]; edges: Edge[] };
+
+export function nfaToGraph(nfa: NFA): Graph {
+  const visited = new Set<number>();
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const queue: Array<{state: any; level: number}> = [{ state: nfa.baslangic, level:0 }];
+  const levelMap: Record<number, number> = {};
+  while (queue.length) {
+    const {state, level} = queue.shift()!;
+    if (visited.has(state.id)) continue;
+    visited.add(state.id);
+    const yIndex = levelMap[level] || 0;
+    levelMap[level] = yIndex + 1;
+    nodes.push({ id: String(state.id), position: { x: level*200, y: yIndex*100 }, data: { label: String(state.id) }, style: state.bitisMi? { border: '3px double black' } : undefined });
+    for (const sym in state.baglanti) {
+      const target = state.baglanti[sym];
+      edges.push({ id: `${state.id}-${sym}-${target.id}`, source: String(state.id), target: String(target.id), label: sym });
+      queue.push({ state: target, level: level+1 });
+    }
+    for (const eps of state.bosBaglanti) {
+      queue.push({ state: eps, level: level+1 });
+    }
+  }
+  return { nodes, edges };
+}
+
+export function dfaToGraph(dfa: DFA): Graph {
+  const visited = new Set<string>();
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const queue: Array<{state: any; level:number}> = [{ state: dfa.baslangic, level:0 }];
+  const levelMap: Record<number, number> = {};
+  while (queue.length) {
+    const {state, level} = queue.shift()!;
+    if (visited.has(state.key)) continue;
+    visited.add(state.key);
+    const yIndex = levelMap[level] || 0;
+    levelMap[level] = yIndex + 1;
+    nodes.push({ id: state.key, position:{x: level*200, y: yIndex*100}, data:{label: state.key}, style: state.kabul? { border: '3px double black' } : undefined });
+    for (const sym in state.baglanti) {
+      const target = state.baglanti[sym];
+      edges.push({ id: `${state.key}-${sym}-${target.key}`, source: state.key, target: target.key, label: sym });
+      queue.push({ state: target, level: level+1 });
+    }
+  }
+  return { nodes, edges };
+}

--- a/src/lib/regexEngine.ts
+++ b/src/lib/regexEngine.ts
@@ -1,0 +1,269 @@
+// Simple regex engine adapted from original project
+
+interface NFAState {
+  id: number;
+  bitisMi: boolean;
+  baglanti: Record<string, NFAState>;
+  bosBaglanti: NFAState[];
+}
+
+export interface NFA {
+  baslangic: NFAState;
+  bitis: NFAState;
+}
+
+interface DFAState {
+  key: string;
+  nfaStates: NFAState[];
+  kabul: boolean;
+  baglanti: Record<string, DFAState>;
+}
+
+export interface DFA {
+  baslangic: DFAState;
+  dfaStates: Record<string, DFAState>;
+}
+
+let stateCounter = 0;
+function resetStateCounter() {
+  stateCounter = 0;
+}
+
+function stateOlustur(bitisMi: boolean): NFAState {
+  return { id: stateCounter++, bitisMi, baglanti: {}, bosBaglanti: [] };
+}
+
+function bosBaglantiEkle(nereden: NFAState, nereye: NFAState) {
+  nereden.bosBaglanti.push(nereye);
+}
+
+function baglantiEkle(nereden: NFAState, nereye: NFAState, sembol: string) {
+  nereden.baglanti[sembol] = nereye;
+}
+
+export function concatOperatoruEkle(regex: string): string {
+  let output = "";
+  for (let i = 0; i < regex.length; i++) {
+    const token = regex[i];
+    output += token;
+    if (token === "(" || token === "|" ) continue;
+    if (i < regex.length - 1) {
+      const sonraki = regex[i + 1];
+      if (sonraki === "*" || sonraki === "+" || sonraki === "|" || sonraki === ")") continue;
+      output += ".";
+    }
+  }
+  return output;
+}
+
+const operatorOnceligi: Record<string, number> = { "|":1, ".":2, "+":3, "*":3 };
+
+function bak<T>(stack: T[]): T | undefined {
+  return stack.length ? stack[stack.length-1] : undefined;
+}
+
+export function postfixDonusumu(regex: string): string {
+  let output = "";
+  const operatorStack: string[] = [];
+  for (const token of regex) {
+    if (token === "." || token === "|" || token === "*" || token === "+") {
+      while (operatorStack.length && bak(operatorStack) !== "(" && operatorOnceligi[bak(operatorStack)!] >= operatorOnceligi[token]) {
+        output += operatorStack.pop();
+      }
+      operatorStack.push(token);
+    } else if (token === "(" || token === ")") {
+      if (token === "(") {
+        operatorStack.push(token);
+      } else {
+        while (bak(operatorStack) !== "(") {
+          output += operatorStack.pop();
+        }
+        operatorStack.pop();
+      }
+    } else {
+      output += token;
+    }
+  }
+  while (operatorStack.length) output += operatorStack.pop();
+  return output;
+}
+
+function bosNFA(): NFA {
+  const baslangic = stateOlustur(false);
+  const bitis = stateOlustur(true);
+  bosBaglantiEkle(baslangic, bitis);
+  return { baslangic, bitis };
+}
+
+function sembolNFA(sembol: string): NFA {
+  const baslangic = stateOlustur(false);
+  const bitis = stateOlustur(true);
+  baglantiEkle(baslangic, bitis, sembol);
+  return { baslangic, bitis };
+}
+
+function concatNFA(birinci: NFA, ikinci: NFA): NFA {
+  bosBaglantiEkle(birinci.bitis, ikinci.baslangic);
+  birinci.bitis.bitisMi = false;
+  return { baslangic: birinci.baslangic, bitis: ikinci.bitis };
+}
+
+function unionNFA(birinci: NFA, ikinci: NFA): NFA {
+  const baslangic = stateOlustur(false);
+  bosBaglantiEkle(baslangic, birinci.baslangic);
+  bosBaglantiEkle(baslangic, ikinci.baslangic);
+  const bitis = stateOlustur(true);
+  bosBaglantiEkle(birinci.bitis, bitis);
+  birinci.bitis.bitisMi = false;
+  bosBaglantiEkle(ikinci.bitis, bitis);
+  ikinci.bitis.bitisMi = false;
+  return { baslangic, bitis };
+}
+
+function yildizNFA(nfa: NFA): NFA {
+  const baslangic = stateOlustur(false);
+  const bitis = stateOlustur(true);
+  bosBaglantiEkle(baslangic, bitis);
+  bosBaglantiEkle(baslangic, nfa.baslangic);
+  bosBaglantiEkle(nfa.bitis, bitis);
+  bosBaglantiEkle(nfa.bitis, nfa.baslangic);
+  nfa.bitis.bitisMi = false;
+  return { baslangic, bitis };
+}
+
+function artiNFA(nfa: NFA): NFA {
+  const baslangic = stateOlustur(false);
+  const bitis = stateOlustur(true);
+  bosBaglantiEkle(baslangic, nfa.baslangic);
+  bosBaglantiEkle(nfa.bitis, bitis);
+  bosBaglantiEkle(nfa.bitis, nfa.baslangic);
+  nfa.bitis.bitisMi = false;
+  return { baslangic, bitis };
+}
+
+function epsilonKapanisi(states: NFAState[]): NFAState[] {
+  const stack = [...states];
+  const closure = new Set<NFAState>(stack);
+  while (stack.length) {
+    const state = stack.pop()!;
+    for (const st of state.bosBaglanti) {
+      if (!closure.has(st)) {
+        closure.add(st);
+        stack.push(st);
+      }
+    }
+  }
+  return Array.from(closure);
+}
+
+function move(states: NFAState[], symbol: string): NFAState[] {
+  const result = new Set<NFAState>();
+  for (const state of states) {
+    const nxt = state.baglanti[symbol];
+    if (nxt) result.add(nxt);
+  }
+  return Array.from(result);
+}
+
+export function NFAToDFA(nfa: NFA): DFA {
+  const stateId = new Map<NFAState, number>();
+  let id = 0;
+  const getId = (st: NFAState) => {
+    if (!stateId.has(st)) stateId.set(st, id++);
+    return stateId.get(st)!;
+  };
+  const keyOf = (states: NFAState[]) => states.map(getId).sort((a,b) => a-b).join(',');
+  const startClosure = epsilonKapanisi([nfa.baslangic]);
+  const dfaStates: Record<string, DFAState> = {};
+  const queue: DFAState[] = [];
+  const createState = (nfaStates: NFAState[]): DFAState => {
+    const key = keyOf(nfaStates);
+    if (dfaStates[key]) return dfaStates[key];
+    const dfaState: DFAState = { key, nfaStates, kabul: nfaStates.some(s=>s.bitisMi), baglanti: {} };
+    dfaStates[key] = dfaState;
+    queue.push(dfaState);
+    return dfaState;
+  };
+  const baslangic = createState(startClosure);
+  while (queue.length) {
+    const current = queue.shift()!;
+    const symbols = new Set<string>();
+    for (const st of current.nfaStates) {
+      for (const sym in st.baglanti) symbols.add(sym);
+    }
+    for (const sym of symbols) {
+      const nextStates = epsilonKapanisi(move(current.nfaStates, sym));
+      const next = createState(nextStates);
+      current.baglanti[sym] = next;
+    }
+  }
+  return { baslangic, dfaStates };
+}
+
+export function NFADonusumu(postfixRegex: string): NFA {
+  if (postfixRegex === "") return bosNFA();
+  const stack: NFA[] = [];
+  for (const token of postfixRegex) {
+    if (token === "*") stack.push(yildizNFA(stack.pop()!));
+    else if (token === "+") stack.push(artiNFA(stack.pop()!));
+    else if (token === "|") { const r = stack.pop()!, l = stack.pop()!; stack.push(unionNFA(l,r)); }
+    else if (token === ".") { const r = stack.pop()!, l = stack.pop()!; stack.push(concatNFA(l,r)); }
+    else stack.push(sembolNFA(token));
+  }
+  return stack.pop()!;
+}
+
+function sonrakiDurumuEkle(state: NFAState, sonraki: NFAState[], gidilmis: NFAState[]) {
+  if (state.bosBaglanti.length) {
+    for (const st of state.bosBaglanti) {
+      if (!gidilmis.includes(st)) {
+        gidilmis.push(st);
+        sonrakiDurumuEkle(st, sonraki, gidilmis);
+      }
+    }
+  } else {
+    sonraki.push(state);
+  }
+}
+
+export function searchNFA(nfa: NFA, kelime: string): Array<{start:number,end:number}> {
+  const results: Array<{start:number,end:number}> = [];
+  for (let i=0; i<kelime.length; i++) {
+    let simdiki: NFAState[] = [];
+    sonrakiDurumuEkle(nfa.baslangic, simdiki, []);
+    for (let j=i; j<kelime.length; j++) {
+      const ch = kelime[j];
+      const sonraki: NFAState[] = [];
+      for (const state of simdiki) {
+        const next = state.baglanti[ch];
+        if (next) {
+          sonrakiDurumuEkle(next, sonraki, []);
+        }
+      }
+      if (sonraki.length === 0) break;
+      if (sonraki.some(s=>s.bitisMi)) results.push({start:i,end:j+1});
+      simdiki = sonraki;
+    }
+  }
+  return results;
+}
+
+export function searchDFA(dfa: DFA, kelime: string): Array<{start:number,end:number}> {
+  const results: Array<{start:number,end:number}> = [];
+  for (let i=0; i<kelime.length; i++) {
+    let current: DFAState | undefined = dfa.baslangic;
+    for (let j=i; j<kelime.length && current; j++) {
+      current = current.baglanti[kelime[j]];
+      if (!current) break;
+      if (current.kabul) results.push({start:i,end:j+1});
+    }
+  }
+  return results;
+}
+
+export function buildNFAFromRegex(regex: string): NFA {
+  resetStateCounter();
+  const withConcat = concatOperatoruEkle(regex);
+  const postfix = postfixDonusumu(withConcat);
+  return NFADonusumu(postfix);
+}


### PR DESCRIPTION
## Summary
- add TypeScript regex engine to build NFAs and convert to DFAs
- visualize automata with React Flow and highlight matches
- create demo page to input regex and text, draw graphs, and search

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "next/typescript")*

------
https://chatgpt.com/codex/tasks/task_e_68b16b59ef40832fa91f6de67d7dd8bc